### PR TITLE
Feature: add font-variant-ligatures to css so that the generated pdf won't have merged characters

### DIFF
--- a/site/src/utils/css.ts
+++ b/site/src/utils/css.ts
@@ -46,7 +46,7 @@ export class DynamicCssService {
   private fontFamily = (selector: string, styles: ResumeStyles) => {
     const fontEN = styles.fontEN.fontFamily || styles.fontEN.name;
     const fontCJK = styles.fontCJK.fontFamily || styles.fontCJK.name;
-    return `${selector} { font-family: ${fontEN}, ${fontCJK}, Arial, Helvetica, sans-serif; }`;
+    return `${selector} { font-family: ${fontEN}, ${fontCJK}, Arial, Helvetica, sans-serif; font-variant-ligatures: none; }`;
   };
 
   private fontSize = (selector: string, styles: ResumeStyles) => {


### PR DESCRIPTION
By selecting the text, you will be able to figure out if the characters are merged or not.

Before:
![image](https://github.com/user-attachments/assets/9ba55b72-459d-4f85-aca5-c959636699d7)

After:
![image](https://github.com/user-attachments/assets/199bd276-2c1a-484b-892e-aa62da286d21)
