### PR TITLE
Feature: Lazy loading for multiple languages

### DIFF
--- a/site/configs/i18n.ts
+++ b/site/configs/i18n.ts
@@ -2,6 +2,7 @@ import type { NuxtI18nOptions } from "@nuxtjs/i18n";
 
 export const i18n: NuxtI18nOptions = {
   defaultLocale: "en",
+  lazy: true,
   strategy: "prefix_and_default",
   locales: [
     {

--- a/site/i18n.config.ts
+++ b/site/i18n.config.ts
@@ -1,4 +1,0 @@
-export default defineI18nConfig(() => ({
-  legacy: false,
-  locale: "en"
-}));


### PR DESCRIPTION
Just add a `@nuxt/i18n` [option](https://i18n.nuxtjs.org/docs/v8/guide/lazy-load-translations)

And remove unused file `i18n.config.ts`
