### PR TITLE
feature: add delete confirmation dialog with type-to-confirm

### DIFF
--- a/site/src/components/dashboard/ResumeOptions.vue
+++ b/site/src/components/dashboard/ResumeOptions.vue
@@ -16,7 +16,7 @@
       size="round"
       variant="destructive"
       class="group/btn gap-x-1 transition-all bg-destructive/90 hover:(bg-destructive w-auto px-2) focus-visible:(w-auto px-2)"
-      @click="remove"
+      @click="openDeleteDialog"
       :aria-label="$t('dashboard.delete')"
     >
       <span i-material-symbols:delete-outline-rounded />
@@ -24,6 +24,38 @@
         {{ $t("dashboard.delete") }}
       </span>
     </UiButton>
+
+    <UiDialog v-model:open="deleteDialogOpen">
+      <UiDialogContent>
+        <UiDialogHeader>
+          <UiDialogTitle>{{ $t('dashboard.delete_confirm.title') }}</UiDialogTitle>
+          <UiDialogDescription>
+            {{ $t('dashboard.delete_confirm.message', { name: props.resume.name }) }}
+          </UiDialogDescription>
+        </UiDialogHeader>
+
+        <div class="py-4">
+          <UiInput
+            v-model="deleteConfirmation"
+            :placeholder="$t('dashboard.delete_confirm.placeholder')"
+            @input="deleteConfirmation = $event.target.value"
+          />
+        </div>
+
+        <UiDialogFooter>
+          <UiButton variant="outline" @click="closeDeleteDialog">
+            {{ $t('dashboard.cancel') }}
+          </UiButton>
+          <UiButton
+            variant="destructive"
+            :disabled="deleteConfirmation !== 'delete'"
+            @click="confirmDelete"
+          >
+            {{ $t('dashboard.delete_confirm.button') }}
+          </UiButton>
+        </UiDialogFooter>
+      </UiDialogContent>
+    </UiDialog>
   </div>
 </template>
 
@@ -38,13 +70,30 @@ const emit = defineEmits<{
   (e: "update"): void;
 }>();
 
+// Delete confirmation dialog state
+const deleteDialogOpen = ref(false);
+const deleteConfirmation = ref("");
+
 const duplicate = async () => {
   await storageService.duplicateResume(props.resume.id);
   emit("update");
 };
 
-const remove = async () => {
-  await storageService.deleteResume(props.resume.id);
-  emit("update");
+const openDeleteDialog = () => {
+  deleteDialogOpen.value = true;
+  deleteConfirmation.value = "";
+};
+
+const closeDeleteDialog = () => {
+  deleteDialogOpen.value = false;
+  deleteConfirmation.value = "";
+};
+
+const confirmDelete = async () => {
+  if (deleteConfirmation.value === "delete") {
+    await storageService.deleteResume(props.resume.id);
+    emit("update");
+    closeDeleteDialog();
+  }
 };
 </script>

--- a/site/src/i18n/en.yaml
+++ b/site/src/i18n/en.yaml
@@ -29,6 +29,12 @@ dashboard:
   rename: Rename
   duplicate: Duplicate
   delete: Delete
+  delete_confirm:
+    title: Delete Resume
+    message: Are you sure you want to delete "{name}"? This action cannot be undone.
+    placeholder: Type 'delete' to confirm
+    button: Delete Resume
+  cancel: Cancel
 
 toolbar:
   file:

--- a/site/src/i18n/sp.yaml
+++ b/site/src/i18n/sp.yaml
@@ -29,6 +29,12 @@ dashboard:
   rename: Renombrar
   duplicate: Duplicar
   delete: Eliminar
+  delete_confirm:
+    title: Eliminar CV
+    message: ¿Estás seguro de que quieres eliminar "{name}"? Esta acción no se puede deshacer.
+    placeholder: Escribe 'delete' para confirmar
+    button: Eliminar CV
+  cancel: Cancelar
 
 toolbar:
   file:

--- a/site/src/i18n/zh-cn.yaml
+++ b/site/src/i18n/zh-cn.yaml
@@ -29,6 +29,12 @@ dashboard:
   duplicate: 创建副本
   rename: 重命名
   delete: 删除
+  delete_confirm:
+    title: 删除简历
+    message: 确定要删除 "{name}" 吗？此操作无法撤销。
+    placeholder: 输入 'delete' 以确认
+    button: 删除简历
+  cancel: 取消
 
 toolbar:
   file:


### PR DESCRIPTION
- Add confirmation dialog when deleting resumes
- Require typing 'delete' to confirm deletion
- Display resume name in confirmation message
- Add translations for all supported languages (EN, ES, ZH-CN)
- Prevent accidental resume deletions